### PR TITLE
Add DuckDuckGo package name to browsers.txt

### DIFF
--- a/android/browsers.txt
+++ b/android/browsers.txt
@@ -238,5 +238,5 @@ com.lemurbrowser.exts
 // https://github.com/AdguardTeam/AdguardForAndroid/issues/5565
 mark.via.gp
 com.xbrowser.play
-//https://github.com/AdguardTeam/CompatibilityIssues/issues/10
+// https://github.com/AdguardTeam/CompatibilityIssues/issues/10
 com.duckduckgo.mobile.android


### PR DESCRIPTION
This change is requested in https://github.com/AdguardTeam/CompatibilityIssues/issues/10.