### PR TITLE
Added 8 apps to https_filtering_apps.json

### DIFF
--- a/windows/https_filtering_apps.json
+++ b/windows/https_filtering_apps.json
@@ -347,5 +347,53 @@
                 "pattern": "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Discord"
             }
         ]
+    },
+    {
+        "name": "Dolby Access",
+        "executable_names": ["DolbyAccess.exe"],
+        "installed_conditions": []
+    },
+    {
+        "name": "Mozilla Thunderbird (Main EXE)",
+        "executable_names": ["thunderbird.exe"],
+        "installed_conditions": []
+    },
+    {
+        "name": "AOMEI Partition Assistant (Main EXEs)",
+        "executable_names": [
+            "PartAssist.exe",
+            "panotify.exe",
+            "amanhlp.exe"
+        ],
+        "installed_conditions": []
+    },
+    {
+        "name": "NVIDIA driver updates' temp .exe",
+        "executable_names": ["nvcontainer.exe"],
+        "installed_conditions": []
+    },
+    {
+        "name": "NVIDIA App",
+        "executable_names": [
+            "NVIDIA App.exe",
+            "NVIDIA Overlay.exe",
+            "NVIDIA App Permission.exe"
+        ],
+        "installed_conditions": []
+    },
+    {
+        "name": "Lovense Remote",
+        "executable_names": ["Lovense_Remote.exe"],
+        "installed_conditions": []
+    },
+    {
+        "name": "CyberLink Ultra HD Blu-Ray Advisor",
+        "executable_names": ["BD_Advisor.exe"],
+        "installed_conditions": []
+    },
+    {
+        "name": "MSN Weather",
+        "executable_names": ["Microsoft.Msn.Weather.exe"],
+        "installed_conditions": []
     }
 ]


### PR DESCRIPTION
These are ones I've tested successfully for several years, which make HTTPS connections, and which (with the exception of Thunderbird default installations) serve various popups/banners/ads over HTTPS.

The apps:
* Dolby Access (Microsoft Store app)
* Mozilla Thunderbird
* AOMEI Partition Assistant
* NVIDIA driver updates' extracted temp installer .exe-s.
* NVIDIA App
* Lovense Remote
* CyberLink Ultra HD Blu-Ray Advisor
* MSN Weather (Microsoft Store app)

Adblock list entries that would not only benefit from this PR, but which also serve as reasons why it should be merged, can be found in the bottom paragraph of https://github.com/DandelionSprout/adfilt/blob/master/AdRemovalListForUnusualAds.txt (which is also a sub-file in Dandelion Sprout's Annoyances List, which in turn is an opt-in in AdGuard for Windows).