### PR TITLE
Mac browsers support

### DIFF
--- a/mac/README.md
+++ b/mac/README.md
@@ -61,15 +61,16 @@ A **JSON array** of objects, each describing a single browser:
 
 ## Object Fields
 
-| Field             | Type     | Required | Description                                                                                      |
-|-------------------|----------|----------|--------------------------------------------------------------------------------------------------|
-| `bundleId`        | `String` | ✓        | Browser application bundle ID                                                                    |
-| `kind`            | `String` | ✓        | Browser engine family: `chrome`, `edge`, or `gecko`                                              |
-| `name`            | `String` | ✓        | Browser application name                                                                         |
-| `profilesFolder`  | `String` | ✓        | Path to the browser profile data directory relative to `~/Library/Application Support`           |
-| `nativeMessaging` | `String` | ✓        | Path to the browser native messaging hosts directory relative to `~/Library/Application Support` |
+| Field                  | Type     | Required | Description                                                                                      |
+|------------------------|----------|----------|--------------------------------------------------------------------------------------------------|
+| `bundleId`             | `String` | ✓        | Browser application bundle ID                                                                    |
+| `kind`                 | `String` | ✓        | Browser engine family: `chrome`, `edge`, or `gecko`                                              |
+| `name`                 | `String` | ✓        | Browser application name                                                                         |
+| `profilesFolder`       | `String` | ✓        | Path to the browser profile data directory relative to `~/Library/Application Support`           |
+| `nativeMessaging`      | `String` | ✓        | Path to the browser native messaging hosts directory relative to `~/Library/Application Support` |
+| `needsHttpsWorkaround` | `Bool`   |          | Does HTTPS support need a workaround? [1]                                                        |
 
-
+[1]: For now, this flag is only relevant for Gecko-like browsers. Some of them (e.g. Tor Browser) require `security.enterprise_roots.enabled` and `security.cert_pinning.enforcement_level` to be set to allow AdGuard for Mac to handle HTTPS connections.
 
 
 ## Example Entry

--- a/mac/browsers.json
+++ b/mac/browsers.json
@@ -165,6 +165,7 @@
         "kind" : "gecko",
         "name" : "Tor Browser",
         "profilesFolder" : "TorBrowser-Data/Browser",
-        "nativeMessaging" : "TorBrowser-Data/Browser/Mozilla/NativeMessagingHosts"
+        "nativeMessaging" : "TorBrowser-Data/Browser/Mozilla/NativeMessagingHosts",
+        "needsHttpsWorkaround" : true
     }
 ]

--- a/mac/browsers.json
+++ b/mac/browsers.json
@@ -149,7 +149,7 @@
     {
         "bundleId" : "org.mozilla.firefoxdeveloperedition",
         "kind" : "gecko",
-        "name" : "Firefox Dev",
+        "name" : "Firefox Developer Edition",
         "profilesFolder" : "Firefox/Profiles",
         "nativeMessaging" : "Mozilla/NativeMessagingHosts"
     },


### PR DESCRIPTION
Fix Firefox Developer Edition name. Add `needsHttpsWorkaround` flag.